### PR TITLE
定时任务改进: feat: 按执行时间升序排列; fix: 修复定时任务重复运行

### DIFF
--- a/core/scheduled_task_manager.py
+++ b/core/scheduled_task_manager.py
@@ -51,6 +51,9 @@ class ScheduledTaskManager(QObject):
                 self._timers[task.schedule_id] = task_info
             all_tasks_for_ui.append(task_info)
 
+        # 按设定时间 time 升序排序
+        all_tasks_for_ui.sort(key=lambda x: x.get('time', '00:00:00'))
+
         self.logger.info(f"从配置中加载了 {len(all_tasks_for_ui)} 个定时任务")
         return all_tasks_for_ui
 


### PR DESCRIPTION
### feat: 定时任务列表按执行时间升序排列
<img width="253" height="565" alt="image" src="https://github.com/user-attachments/assets/3557feeb-cb8e-41b2-b871-d55b91caacbe" />


### fix: 修复定时器精度导致的定时任务触发两次
log:
2026-01-20 04:04:59 - DEBUG - 周期性任务b2536427 已执行，正在安排下一次运行。
2026-01-20 04:04:59 - DEBUG - 开始为任务b2536427 计算下次时间。当前时间: 2026-01-20 04:04:59 Tuesday, 目标时间: 04:05:00, 类型: 每日执行
2026-01-20 04:04:59 - INFO - 定时任务b2536427 (WS_1) 已设置，将在2026-01-20 04:05:00 首次运行(延迟: 471 ms)

计算下次时间时为当前时间添加10s与目标时间进行比较
